### PR TITLE
Adding the Deutsche Telekom as interested party

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -75,3 +75,4 @@ Deliverables
 - Orange
 - MATRIXX
 - Nokia
+- Deutsche Telekom


### PR DESCRIPTION
As representative of Deutsche Telekom Technik's Kubernetes Engine team, I would like to rise our intention to take active part in this working group. 