### PR TITLE
Making goals more concise + removing conformance language

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -6,7 +6,7 @@ The goal of the Cloud Native Network Function Working Group (CNF WG)  is to aid 
 The CNF WG operates under the aegis of CNCF. The focus of the CNF WG is to define the process around evaluating the cloud nativeness of networking applications, aka CNFs, running on Kubernetes. We collaborate with the [CNF test suite project](https://github.com/cncf/cnf-conformance/blob/master/README-testsuite.md) who works on the mechanics of the tests.
 
 The goals for the group are:
-- To identify best practices for CNFs running on Kubernetes which CNF Developers and operators alike may adopt
+- To identify cloud native best practices for CNFs running on Kubernetes which CNF Developers and operators alike may adopt
 - To determine which practices will allow networking applications to most effectively utilize Kubernetes capabilities and services
 
 

--- a/charter.md
+++ b/charter.md
@@ -7,7 +7,7 @@ The CNF WG operates under the aegis of CNCF. The focus of the CNF WG is to defin
 
 The goals for the group are:
 - To identify best practices for CNFs running on K8s which CNF Developers and operators alike may adopt
-- To determine which practices will allow networking applications to most efficiently utilize K8s capabilities and services
+- To determine which practices will allow networking applications to most effectively utilize Kubernetes capabilities and services
 
 
 ## Mission Statement

--- a/charter.md
+++ b/charter.md
@@ -6,7 +6,7 @@ The goal of the Cloud Native Network Function Working Group (CNF WG)  is to aid 
 The CNF WG operates under the aegis of CNCF. The focus of the CNF WG is to define the process around evaluating the cloud nativeness of networking applications, aka CNFs, running on Kubernetes. We collaborate with the [CNF test suite project](https://github.com/cncf/cnf-conformance/blob/master/README-testsuite.md) who works on the mechanics of the tests.
 
 The goals for the group are:
-- To identify best practices for CNFs running on K8s which CNF Developers and operators alike may adopt
+- To identify best practices for CNFs running on Kubernetes which CNF Developers and operators alike may adopt
 - To determine which practices will allow networking applications to most effectively utilize Kubernetes capabilities and services
 
 

--- a/charter.md
+++ b/charter.md
@@ -6,8 +6,8 @@ The goal of the Cloud Native Network Function Working Group (CNF WG)  is to aid 
 The CNF WG operates under the aegis of CNCF. The focus of the CNF WG is to define the process around evaluating the cloud nativeness of networking applications, aka CNFs, running on Kubernetes. We collaborate with the [CNF test suite project](https://github.com/cncf/cnf-conformance/blob/master/README-testsuite.md) who works on the mechanics of the tests.
 
 The goals for the group are:
-- To create a program which identifies best practices for CNFs running on K8s which CNF Developers and operators alike may use to demonstrate how well their software and its operation adhere to cloud native principles.
-- To determine which practices will allow telco applications to most efficiently utilize K8s to lower the operational risk and burdens of service providers and telco vendors
+- To identify best practices for CNFs running on K8s which CNF Developers and operators alike may adopt
+- To determine which practices will allow networking applications to most efficiently utilize K8s capabilities and services
 
 
 ## Mission Statement


### PR DESCRIPTION
Removing old language related to conformance program. Groups main goal is identifying best practices for CNFs. The purpose of that is to get the benefits into developer and operator hands. Adherence to the principles is only a means to the end of gaining the benefits and not the purpose itself.

As part of showing best practices we will be finding practices that are specifically applicable to networking applications and showing how they can leverage the capabilities in K8s (as a platform and framework).