### PR TITLE
Markdown link checking

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,8 @@
+name: Check Markdown links
+on: [push, pull_request]
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/ccdps/0001-cnf-conformance-definition-proposal-process.md
+++ b/ccdps/0001-cnf-conformance-definition-proposal-process.md
@@ -72,7 +72,7 @@ The definition of what constitutes a Cloud Native best practice or principle is 
 
 **CCDP Template**
 
-The template for a CCDP is defined [here](https://github.com/cncf/cnf-wg/blob/requirements-to-best-practices/ccdps/NNNN-ccdp-template.md).
+The template for a CCDP is defined [here](./NNNN-ccdp-template.md).
 
  **Important Metrics**
 

--- a/doc/best_cnf_dev.md
+++ b/doc/best_cnf_dev.md
@@ -19,7 +19,8 @@
 
 **Description**: Some Description here
 
-**Link to CCDP**: [CCDP-0001](../ccdps/xyz.md)
+<!-- This is an example and therefore the link is broken. -->
+i<!-- markdown-link-check-disable-line -->**Link to CCDP**: [CCDP-0001](../ccdps/xyz.md)
 
 
 
@@ -27,7 +28,8 @@
 
 **Description**: Some Description here
 
-**Link to CCDP**: [CCDP-0002](../ccdps/xyz.md)
+<!-- This is an example and therefore the link is broken. -->
+<!-- markdown-link-check-disable-line -->**Link to CCDP**: [CCDP-0002](../ccdps/xyz.md)
 
 
 

--- a/doc/best_cnf_dev.md
+++ b/doc/best_cnf_dev.md
@@ -20,7 +20,8 @@
 **Description**: Some Description here
 
 <!-- This is an example and therefore the link is broken. -->
-i<!-- markdown-link-check-disable-line -->**Link to CCDP**: [CCDP-0001](../ccdps/xyz.md)
+<!-- markdown-link-check-disable-next-line -->
+**Link to CCDP**: [CCDP-0001](../ccdps/xyz.md)
 
 
 
@@ -29,7 +30,8 @@ i<!-- markdown-link-check-disable-line -->**Link to CCDP**: [CCDP-0001](../ccdps
 **Description**: Some Description here
 
 <!-- This is an example and therefore the link is broken. -->
-<!-- markdown-link-check-disable-line -->**Link to CCDP**: [CCDP-0002](../ccdps/xyz.md)
+<!-- markdown-link-check-disable-next-line -->
+**Link to CCDP**: [CCDP-0002](../ccdps/xyz.md)
 
 
 


### PR DESCRIPTION
We had a couple of broken link incidents in another pull request.  This helps ensure we don't have that sort of thing again.

- [x] added linting github action on pull request, push
- [x] fixed a broken link
- [x] excluded check of a deliberately broken example link