### PR TITLE
Clarifying the responsibilities of the Governing Chairs

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -79,9 +79,8 @@ Deliverables
 #### Chairs
 
 The CNF WG will be co-chaired by 3 people: at least one co-chair from the Kubernetes (K8s) Community, one from the Service Provider (SP) Community and one from the CNF Developer (Dev) Community to have equal representation.
-- *Primary role of Chairs is to run operations and the governance of the group.*
-- The Chairs are responsible for ensuring that group meetings are planned and facilitated effectively, while also engaging group members in leadership roles. Effective facilitation includes (but is not limited to) the following activities:
-    - setting the agenda for meetings
+- *Primary role of Chairs is governance of the group.*
+- The Chairs are responsible for ensuring that group meetings are facilitated effectively, while also engaging group members in leadership roles. Effective facilitation includes the following activities:
     - extending discussion via asynchronous communication to be inclusive of members who cannot attend a specific meeting time
     - scheduling discussion of proposals that have been submitted
     - asking for new proposals to be made to address an identified need


### PR DESCRIPTION
The Chair role responsibilities left some things ambiguous and was overreaching with a couple of items.  This role is focused on governing of the working group. Other activities should be left to the community to decide and discuss.

As seen in The Art of Community by Jono Bacon (2009), common responsibilities for a council (aka governing body) include:
- membership approval/rejection
- conflict resolution
- project values
- community process changes
- ordaining governance bodies
- direction

The governing council does not
- act as a bottle neck to choose people for small roles
- set feature direction when there are excellent contributors not on the council
- approve formation of a new team

Reference:
- https://www.jonobacon.com/books/artofcommunity/ ([Creative Commons licensed PDF](https://drive.google.com/file/d/1EI6YcKlTdzojLD4RdVjYVlmFRTNzzge0/view))