### PR TITLE
add YouTube URL and KubeCon event to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,29 @@ The Cloud Native Network Function WG (CNF WG) operates under the aegis of CNCF. 
 
 The goal for the group is to create a software conformance program that any network application implementation can use to determine how well it follows cloud native principles and best practices.
 
-The [CNF WG Charter](https://github.com/cncf/cnf-wg/blob/master/charter.md) futher outlines the scope of our group activities as well as intended deliverables.
+The [CNF WG Charter](charter.md) futher outlines the scope of our group activities as well as intended deliverables.
 
 The CNF Conformance program will evaluate cloud nativeness based on the set of best practices in which the CNF WG has selected following the [CNF Conformance Definition Proposal](ccdps). Anyone in the CNF WG is welcome to participate in the process from creation to selection of proposals.
 
 
 ## Meetings
-Recurring meetings:
+
+### Recurring meetings:
 - Weekly on Mondays at 16:00 UTC (8:00am Pacific Time)
 - Agenda and notes are [available](https://docs.google.com/document/d/1YFimQftjkTUsxNGTsKdakvP7cJtJgCTqViH2kwJOrsc/edit)
 - Join zoom meeting [here](https://zoom.us/j/97556246445?pwd=VTMrSjRWQ3pSMVZGQmNRemEwUk14QT09)
   - Passcode: :zero::four::zero::nine::six::three:
-- Recordings of previous meetings: YouTube URL, TBD
+- Recordings of previous meetings: [CNF WG Playlist on YouTube](https://youtube.com/playlist?list=PLj6h78yzYM2PyMYvw5wiH01hthFb0qrOn)
 
-### Past meetings
+### Upcoming events:
 
-[Cloud Native Network Functions (CNF) Working Group Kick-off](https://sched.co/fRkx) at KubeCon:
+[CNF WG: K8s Best Practices for Telco Apps](https://sched.co/iE74) at KubeCon EU 2021
+- Thursday, May 6 at 11:30 - 12:05 UTC
+- [Register](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/)
+
+### Past events:
+
+[Cloud Native Network Functions (CNF) Working Group Kick-off](https://sched.co/fRkx) at KubeCon NA 2020:
 - Thursday, November 19th at 16:00 UTC (11:00am - 12:00pm EST)
 - Join zoom [here](https://zoom.us/j/92899637746)
 


### PR DESCRIPTION
Changes: 
- Changed link for [CNF WG Charter](charter.md)
- Added link for [CNF WG Playlist on YouTube](https://youtube.com/playlist?list=PLj6h78yzYM2PyMYvw5wiH01hthFb0qrOn)
- Added Upcoming events section for KubeCon EU 2021