### PR TITLE
update cnf test suite url, add co-chair usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ The primary goal for this group is to provide a set of cloud native + Kubenative
 
 The [CNF WG Charter](charter.md) futher outlines the scope of our group activities as well as intended deliverables.
 
-The [CNF Test Suite](https://github.com/cncf/cnf-conformance) will support testing a set of these best practices to allow developers and network operators to evaluate how well a network application follows cloud native principles and best practices. Proposals which have been adopted by the CNF WG are listed in the [CNF Best Practice Proposal](cbpps/) folder.
+The [CNF Test Suite](https://github.com/cncf/cnf-testsuite) will support testing a set of these best practices to allow developers and network operators to evaluate how well a network application follows cloud native principles and best practices. Proposals which have been adopted by the CNF WG are listed in the [CNF Best Practice Proposal](cbpps/) folder.
 
 ## Meetings
 
 ### Current Co-Chairs
 
-* Service Provider Co-Chair: Jeffrey Saelens
-* CNF Developer Co-Chair: Ian Wells
-* Kubernetes Co-Chair: Taylor Carpenter
+* Service Provider Co-Chair: Jeffrey Saelens, [@jeffsaelens](https://github.com/jeffsaelens)
+* CNF Developer Co-Chair: Ian Wells, [@iawells](https://github.com/iawells)
+* Kubernetes Co-Chair: Taylor Carpenter, [@taylor](https://github.com/taylor)
 
 ### Recurring meetings
 


### PR DESCRIPTION
Documentation changes in README

Including: 

- updating URL For The [CNF Test Suite](https://github.com/cncf/cnf-testsuite) 
- Adding usernames for:
  - Service Provider Co-Chair: Jeffrey Saelens, [@jeffsaelens](https://github.com/jeffsaelens)
  - CNF Developer Co-Chair: Ian Wells, [@iawells](https://github.com/iawells)
  - Kubernetes Co-Chair: Taylor Carpenter, [@taylor](https://github.com/taylor)