### PR TITLE
Using individual names + company for interested parties

### DIFF
--- a/interested-parties.md
+++ b/interested-parties.md
@@ -27,7 +27,7 @@
 - [Miroslav Miklus](@mmiklus), PANTHEON.tech
 - Lisa Caywood, Red Hat
 - [Shane Ronan](@sronanrh), Red Hat
-- [Tal Liron](Tal Liron), Red Hat
+- [Tal Liron](@tliron), Red Hat
 - [Ranny Haiby](@rannyh), Samsung
 - [Victor Morales](@electrocucaracha), Samsung
 - Clément Nussbaumer, Swisscom
@@ -36,8 +36,8 @@
 - Jambi Ganbar, VMware
 - [Tom Kivlin](@tomkivlin), Vodafone
 - [Drew Bentley](@agentpoyo), Vulk Coop
-- [Lucina Stricko](@lixuna], Vulk Coop
-- [Taylor Carpenter](@taylor], Vulk Coop
+- [Lucina Stricko](@lixuna), Vulk Coop
+- [Taylor Carpenter](@taylor), Vulk Coop
 - [W. Watson](@wavell), Vulk Coop
 
 

--- a/interested-parties.md
+++ b/interested-parties.md
@@ -1,29 +1,44 @@
 # Interested Parties
 
-- ARM
-- AT&T
-- AWS
-- Bell Canada
-- Charter Communications
-- Chunghwa Telecom
-- Cisco
-- Deutsche Telekom
-- Equinix
-- Frederick F. Kautz IV
-- Google
-- Huawei
-- Ildiko Vancsa
-- InfraCloud
-- Intel
-- Mars Toktonaliev
-- MATRIXX
-- Nikolay Nikolaev
-- Nokia
-- Orange
-- PANTHEON.tech
-- Red Hat
-- Samsung
-- Swisscom
-- VMware
-- Vodafone
-- Vulk Coop
+- [Philippe Robin](@philipperobin), ARM
+- [Pankaj Goygal](pgoyal01), AT&T
+- [Rabi Abdel](@rabi-abdel), AWS
+- Daniel Bernier, Bell Canada
+- [Jeffrey Saelens](@jeffsaelens), Charter Communications
+- [Aiden Huang](@Aiden128),Chunghwa Telecom
+- [Ian Wells](@iawells), Cisco
+- Michal Sewera, Deutsche Telekom
+- [Vuk Gojnic](vukg), Deutsche Telekom
+- [Claudio Bartolini](claudiobartolini), Equinix
+- [Frederick F. Kautz IV](@fkautz), Doc.ai
+- Maciej Skrocki, Google
+- Randolph Chung, Google
+- [mkr1481](@mkr1481), Huawei
+- [Ildiko Vancsa](@ildikov), Open Infrastructure Foundation
+- Chitrabasu Khare, InfraCloud
+- [Michael Pedersen](@michaelspedersen), Intel
+- [Petar Torre](@petorre), Intel
+- [Simon Billingsley](@sishbi), MATRIXX
+- [Olivier Smith](@Smitholi67), MATRIXX
+- [Nikolay Nikolaev](@nickolaev), Kong
+- [Gergely Csatari](CsatariGergely), Nokia
+- [Mars Toktonaliev](@tokt), Nokia
+- Cristian Calin, Orange
+- [Miroslav Miklus](@mmiklus), PANTHEON.tech
+- Lisa Caywood, Red Hat
+- [Shane Ronan](@sronanrh), Red Hat
+- [Tal Liron](Tal Liron), Red Hat
+- [Ranny Haiby](@rannyh), Samsung
+- [Victor Morales](@electrocucaracha), Samsung
+- Clément Nussbaumer, Swisscom
+- [Ruben Merz](rmerz), Swisscom
+- [Bryan Liles](@bryanl), VMware
+- Jambi Ganbar, VMware
+- [Tom Kivlin](@tomkivlin), Vodafone
+- [Drew Bentley](@agentpoyo), Vulk Coop
+- [Lucina Stricko](@lixuna], Vulk Coop
+- [Taylor Carpenter](@taylor], Vulk Coop
+- [W. Watson](@wavell), Vulk Coop
+
+
+


### PR DESCRIPTION
This adds the names of individuals who have expressed interest along with the company they work for.

This change is compatible with the [charter as-is](https://github.com/cncf/cnf-wg/blob/main/GOVERNANCE.md#elections).

Ref:

- https://github.com/cncf/cnf-wg/issues/143
- https://github.com/cncf/cnf-wg/discussions/126 
