### PR TITLE
CNF definition

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -59,6 +59,7 @@ For the purpose of this document, “Company” shall mean any entity (Company-A
 Each organization listed in the [interested parties document](interested-parties.md) has one vote. Interested parties can be added at any time, but must be added at least one week before any election to have a vote. Any contributor from an organization may cast the vote for that organization. Each organization can cast one vote for a co-chair candidate in each of the communities (Kubernetes (K8s) Community, Service Provider (SP) Community, and CNF Developer (Dev) Community), three total votes.
 
 ### Voting Procedure
+
 The chair for each community will be elected using [Ranked Choice Voting](https://en.wikipedia.org/wiki/Ranked_voting).
 
 ## Independence

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF has been developed using Cloud Native Principles and allows for a “repeatable deployment process”.
+**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) that implements network functionality. A CNF has been developed using Cloud Native Principles and allows for a “repeatable deployment process”.
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud-Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF consists of one or more microservices and has been developed using Cloud Native Principles including immutable infrastructure, declarative APIs, and a “repeatable deployment process”.
+**Cloud Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF consists of one or more microservices which can be delivered and has been developed using Cloud Native Principles including loose coupling, immutable infrastructure, declarative APIs, and a “repeatable deployment process”.
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md), developed using cloud native principles, that provides network functionality. 
+**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) that provides network functionality, which is developed using cloud native principles. 
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) that implements network functionality. A CNF is developed using Cloud Native Principles to enable desired behavior such as “repeatable deployment process”.
+**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) developed using Cloud Native principles that provides network functionality. 
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF consists of one or more microservices which can be delivered and has been developed using Cloud Native Principles including loose coupling, immutable infrastructure, declarative APIs, and a “repeatable deployment process”.
+**Cloud Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF has been developed using Cloud Native Principles and allows for a “repeatable deployment process”.
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud-Native** - TBD
 
-**Cloud-Native Network Function** - TBD
+**Cloud-Native Network Function** - A cloud native network function (CNF) is a cloud native application that implements network functionality. A CNF consists of one or more microservices and has been developed using Cloud Native Principles including immutable infrastructure, declarative APIs, and a “repeatable deployment process”.
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. <Kubernetes.io>
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) developed using Cloud Native principles that provides network functionality. 
+**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md), developed using cloud native principles, that provides network functionality. 
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,7 +6,7 @@
 
 **Cloud Native** - TBD
 
-**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) that implements network functionality. A CNF has been developed using Cloud Native Principles and allows for a “repeatable deployment process”.
+**Cloud Native Network Function** - A cloud native network function (CNF) is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md) that implements network functionality. A CNF is developed using Cloud Native Principles to enable desired behavior such as “repeatable deployment process”.
 
 **Kubernetes** - Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available. [Kubernetes.io](https://kubernetes.io/)
 


### PR DESCRIPTION
Update to the glossary with second crack at the CNF definition. The term cloud native will be referenced with the assumption that it too will be spelled out in more detail in the glossary. This PR will be for a single definition that the group can focus on. Please reference discussions #136 and #27 .