### PR TITLE
Fix Broken Links false positives

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [429, 200]
+}


### PR DESCRIPTION
Broken links CI is reporting [429 HTTP codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) as errors for external links. This change modifies its configuration to ignore that HTTP code.