### PR TITLE
Add a format version to the CBPP template

### DIFF
--- a/cbpps/NNNN-cbpp-template.md
+++ b/cbpps/NNNN-cbpp-template.md
@@ -3,6 +3,7 @@
      Minor: changes when we alter formatting without changing content requirements
      Keep the first line of this comment in your best practice,
      to help us track formatting updates --> 
+     
 # **CBPP-NNNN: Your short, descriptive title (TEMPLATE)**
 
 - [Release Signoff Checklist](#release-signoff-checklist)

--- a/cbpps/NNNN-cbpp-template.md
+++ b/cbpps/NNNN-cbpp-template.md
@@ -1,3 +1,8 @@
+<!-- Created from CBPP template v1.0
+     Major: changes when we add or remove sections or demands for information
+     Minor: changes when we alter formatting without changing content requirements
+     Keep the first line of this comment in your best practice,
+     to help us track formatting updates --> 
 # **CBPP-NNNN: Your short, descriptive title (TEMPLATE)**
 
 - [Release Signoff Checklist](#release-signoff-checklist)


### PR DESCRIPTION
Add a template version that will be preserved in the CBPPs created
from the template.

The aim is to detect when we've rejigged our template so that
we can tell which best practices need updating if we don't do
that at the same time.