### PR TITLE
Fix linting issues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: github/super-linter@v3
+      - uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /

--- a/cbpps/NNNN-cbpp-template.md
+++ b/cbpps/NNNN-cbpp-template.md
@@ -2,8 +2,8 @@
      Major: changes when we add or remove sections or demands for information
      Minor: changes when we alter formatting without changing content requirements
      Keep the first line of this comment in your best practice,
-     to help us track formatting updates --> 
-     
+     to help us track formatting updates -->
+
 # **CBPP-NNNN: Your short, descriptive title (TEMPLATE)**
 
 - [Release Signoff Checklist](#release-signoff-checklist)

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -2,12 +2,11 @@
 
 ## Specification
 
-
 ### Community Definitions
 
 **Cloud Native**: TBD
 
-**Cloud Native Network Function (CNF)**: A network function that is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md), i.e. developed using cloud native principles. 
+**Cloud Native Network Function (CNF)**: A network function that is a [cloud native application](https://github.com/cncf/glossary/blob/main/definitions/cloud_native_apps.md), i.e. developed using cloud native principles.
 
 **Kubernetes**: [Kubernetes.io](https://kubernetes.io/) is a portable, extensible, open-source platform for managing workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 
@@ -19,7 +18,6 @@
 
 **Virtualized Network Function (VNF)**: A network function deployed entirely or primarily using virtualization technologies, which comprise both hardware and software features and include CPU, RAM, and GPU support, as well as bus features such as SR-IOV. Virtualization technologies are available in hypervised virtual machines as well as containers (see: Containerized network function). Note that a VNF is not necessarily a cloudified network function. Indeed, the history of NFV—the effort to virtualize network functions—predates the move to cloud platforms.
 
-
 ### CNF WG Specific Definitions
 
 **Containerized network function**: A network function deployed entirely or primarily as one or more containers. Should not be referred to by the "CNF" acronym in order to avoid confusion with Cloud Native Network Function (CNF). Note that this definition specifies the runtime technology only, not the platform. Thus a containerized network function might not target Kubernetes nor indeed any cloud platform. Also note that some containerization technologies include virtualization features (see also: VNF).
@@ -27,7 +25,6 @@
 **Kube-Native**: TBD
 
 **Additional Definitions?**
-
 
 ## References
 


### PR DESCRIPTION
New changes added in glossary and the CBPP template causes some linting issues in the CI. This change fixes those errors to avoid false positives in future changes.