### PR TITLE
Fix spellings and linting CI issues

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -47,6 +47,7 @@ Cristian
 Csatari
 CsatariGergely
 CSP
+CSP's
 CSPs
 dataplane
 deliverables
@@ -69,6 +70,7 @@ Ganbar
 GC
 Gergely
 getters
+GitOps
 GL
 Gojnic
 golang
@@ -104,6 +106,7 @@ KubeCon
 kubenative
 kubernetes
 kwJOrsc
+learnk
 lifecycle
 Lifecycle
 Liles
@@ -130,6 +133,7 @@ namespaces
 nativeness
 NFs
 NFV
+NFVi
 nickolaev
 NICs
 Nikolaev
@@ -139,6 +143,7 @@ notesconstraintscaveats
 Nussbaumer
 observability
 ol
+onboarding
 OSS
 overrepresented
 OVP
@@ -155,6 +160,7 @@ PNF
 png
 Postconditions
 pre
+prem
 PRs
 pSMVZGQmNRemEwUk
 PV
@@ -184,6 +190,7 @@ signoff
 SIGs
 sishbi
 Skrocki
+SLA
 SMF
 Smitholi
 snetworkplumbingwg
@@ -241,5 +248,6 @@ WIP
 writeup
 XDP
 xyz
+yaml
 YFimQftjkTUsxNGTsKdakvP
 yzYM

--- a/use-case/0004-UC-onboarding-of-CNF-to-the-CSP-platform.md
+++ b/use-case/0004-UC-onboarding-of-CNF-to-the-CSP-platform.md
@@ -26,7 +26,7 @@ Data Center Network
 Wide Area Network
 Cloud Native Platform
 CNF
-CICD
+CI/CD
 
 ## Situation
 
@@ -34,21 +34,21 @@ CNF DevOps teams in CSP are responsible for the introduction and lifecycle of th
 
 In CNF case the assumption is that the platform is already there, that it is in its core Kubernetes based without special forks as well as that different components needed by CNF could be installed via Kubernetes API.
 
-This creates the situation in which CNF and CSP platform, both of which have their requirements and pre-conditions, meet each other as such for the first time. The process of getting the CNF deployed on the platform in aforementioned scenario is colloquially called "onboarding". In this process CNF vendor, CNF DevOps and CNPD work together to reach common gloal of having production grade deployment of CNF supported with appropriate SLA which factors-in the fact that CNF runs on CSP platform.  
+This creates the situation in which CNF and CSP platform, both of which have their requirements and pre-conditions, meet each other as such for the first time. The process of getting the CNF deployed on the platform in aforementioned scenario is colloquially called "onboarding". In this process CNF vendor, CNF DevOps and CNPD work together to reach common goal of having production grade deployment of CNF supported with appropriate SLA which factors-in the fact that CNF runs on CSP platform.
 
 ## Expected behaviour
 
 CNF vendor expects that CSP platform and environment (e.g. Network) are fulfilling certain requirements and preconditions for CNF to be able to achieve production grade deployment. These requirements are different from CNF to CNF.
 
-CNPD expects that all requirements are well documented with and provided in such form before onboarding starts. The docummentation shall enable CNPD team to verify readiness and prepare the platform (e.g. configure necessary kernel modules, SR-IOV interfaces and similar). In practically all deployments that are meant for production environment the deployment artifacts are stored in private on-prem artifacts and registries. Therefore CNPD expects that CNF vendor provides its artefacts in a form that is typical for cloud native applications (Helm charts, containers, yaml manifests) which could be easily replicated to CSP's on-prem environment (e.g. CNF vendor's registry accessible via Internet from CSPs caching registry).
+CNPD expects that all requirements are well documented with and provided in such form before onboarding starts. The documentation shall enable CNPD team to verify readiness and prepare the platform (e.g. configure necessary kernel modules, SR-IOV interfaces and similar). In practically all deployments that are meant for production environment the deployment artifacts are stored in private on-prem artifacts and registries. Therefore CNPD expects that CNF vendor provides its artefacts in a form that is typical for cloud native applications (Helm charts, containers, yaml manifests) which could be easily replicated to CSP's on-prem environment (e.g. CNF vendor's registry accessible via Internet from CSPs caching registry).
 
-CNF DevOps team expects to deploy and configure the CNF application on their own, preferably directly via automation pipelines and in interaction and cooperation with CNPD and CSP Network teams. For that they expect to receive well documented installation procedures, references for typical continuous deployment realisations with that particular or similar CNFs as well as comprehensive deployment troubleshooting guide. As already mentioned in (UC0001)[0001-UC-lifecycle-of-infrastructure-where-CNF-is-running.md], CNF DevOps team also expects to get suite of tests from CNF vendor. Tests could then be deployed in continuous testing pipeline to automatically verify that CNF is running properly (production grade) on the platform and that the deployment qualifies for SLA.
+CNF DevOps team expects to deploy and configure the CNF application on their own, preferably directly via automation pipelines and in interaction and cooperation with CNPD and CSP Network teams. For that they expect to receive well documented installation procedures, references for typical continuous deployment realisations with that particular or similar CNFs as well as comprehensive deployment troubleshooting guide. As already mentioned in [UC0001](0001-UC-lifecycle-of-infrastructure-where-CNF-is-running.md), CNF DevOps team also expects to get suite of tests from CNF vendor. Tests could then be deployed in continuous testing pipeline to automatically verify that CNF is running properly (production grade) on the platform and that the deployment qualifies for SLA.
 
 The starting point of onboarding shall be extension of platform with any requirements and dependencies that are coming from CNF. When all conditions on the platform level are met, the deployment of CNF shall proceed.
 
 ## Challenges and limitations with Kube-native approach
 
-Most of the CNFs today, especially complex ones, are packaged in such way that only trained professional service teams of the CNF vendor can reasonably deploy them. The documentation and manuals that come with those CNFs are giving same impression. The onboarding today usually requires intensive interation between CNF vendor, CNF DevOps and CNPD teams and lots of trial/error tuning and manual adaptations on both platform and CNF side.
+Most of the CNFs today, especially complex ones, are packaged in such way that only trained professional service teams of the CNF vendor can reasonably deploy them. The documentation and manuals that come with those CNFs are giving same impression. The onboarding today usually requires intensive interaction between CNF vendor, CNF DevOps and CNPD teams and lots of trial/error tuning and manual adaptations on both platform and CNF side.
 
 The CNFs are also regularly packaged to be suitable for opinionated installers that are typically part of vendor's own platform offering or particular platform blueprint. The onboarding on CSP's own platform in such cases frequently involves sort of reverse engineering of CNF vendor's installer to come to basic cloud native artefacts and derive requirements from installer's code with the help of vendor's engineers.
 
@@ -66,4 +66,4 @@ The practices already exist outside of CNF world, but are not very well followed
 
 ### What needs to be done differently in order to overcome challenges and limitations
 
-CNF vendors need to start preparing CNFs for shipping as regular cloud software that is well docummented and that can be deployed and configured by CNF DevOps team. Following established best practices for cloud native software distribution and deployment would improve the situation significantly.
+CNF vendors need to start preparing CNFs for shipping as regular cloud software that is well documented and that can be deployed and configured by CNF DevOps team. Following established best practices for cloud native software distribution and deployment would improve the situation significantly.


### PR DESCRIPTION
Previous commits added some typos and linting issues. This change fix those files adding words into the dictionary.