### PR TITLE
Adding supply chain attack user stories

### DIFF
--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -73,22 +73,20 @@ User/group access enforcement will be respected. As an added advantage, fine-gra
 
 ### User Story
 
-#### A containerized OpenVSwitch downloads compromised routing updates
+## Supply chain attack user stories
 
-An OpenVSwitch VNF was containerized and is running on a K8s cluster. It retrieves its routing scripts and logic, which are defined externally, from a remote service. It then applies them to the running container instance.
+[Supply chain attacks](user-stories/supply-chain-attacks.md) are a risk at any point in the supply chain. ‘Defence in depth’ says that we should (a) defend against supply chain attacks but also (b) add mitigations in the case that supply chain attacks happen.
 
-Unfortunately, the latest resources it downloaded have been compromised. The  OpenVSwitch runs the compromised code which takes over the container’s process with its own malicious code.
+Examples include
+- A CNF downloads compromised updates
+- A CNF succumbs to code injection
+- A CNF succumbs to malicious instructions
+- A CNF has a security-compromising bug
 
-With this best practice, the now malicious application will not be able to escalate its damage beyond what the non-root user has access to.
+In all of these examples, the CNFs using a non-root user for their container processes, have limited the scope of damage a compromised process may cause.
 
+See main [defense in depth for supply chain attacks](user-stories/supply-chain-attacks.md) document for more inforamtion.
 
-#### A Firewall as a Service (FWaaS) CNF  downloads compromised externally defined rules
-
-A firewall running on a K8s cluster applies rules from an external, centralized system. These firewall rules are applied “hot” to the running container and are expected to be pre-validated by the external system.
-
-Unfortunately, the latest set of rules include an exploit while still passing validation by the external system and the firewall CNF itself. The firewall downloads the newly defined rules with the exploit and when they are applied the firewall container is compromised with malicious code.
-
-With this best practice, the now malicious firewall CNF will not be able to escalate its damage beyond what the non-root user has access to.
 
 ### Tradeoffs/Constraints/Caveats/Notes
 

--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -83,7 +83,7 @@ Examples include
 
 In all of these examples, the CNFs using a non-root user for their container processes, have limited the scope of damage a compromised process may cause.
 
-See main [defense in depth for supply chain attacks](../user-stories/supply-chain-attacks.md) document for more inforamtion.
+See main [defense in depth for supply chain attacks](../user-stories/supply-chain-attacks.md) document for more information.
 
 
 ### Tradeoffs/Constraints/Caveats/Notes

--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -76,10 +76,10 @@ User/group access enforcement will be respected. As an added advantage, fine-gra
 [Supply chain attacks](user-stories/supply-chain-attacks.md) are a risk at any point in the supply chain. ‘Defence in depth’ says that we should (a) defend against supply chain attacks but also (b) add mitigations in the case that supply chain attacks happen.
 
 Examples include
-- [A CNF downloads compromised updates](user-stories/supply-chain-attacks.md#a-cnf-downloads-compromised-updates)
-- [A CNF succumbs to code injection](user-stories/supply-chain-attacks.md#a-cnf-succumbs-to-code-injection)
-- [A CNF succumbs to malicious instructions](ser-stories/supply-chain-attacks.md#a-cnf-succumbs-to-malicious-instructions)
-- [A CNF has a security-compromising bug](user-stories/supply-chain-attacks.md#a-cnf-has-a-security-compromising-bug)
+- [A CNF downloads compromised updates](../user-stories/supply-chain-attacks.md#a-cnf-downloads-compromised-updates)
+- [A CNF succumbs to code injection](../user-stories/supply-chain-attacks.md#a-cnf-succumbs-to-code-injection)
+- [A CNF succumbs to malicious instructions](../user-stories/supply-chain-attacks.md#a-cnf-succumbs-to-malicious-instructions)
+- [A CNF has a security-compromising bug](../user-stories/supply-chain-attacks.md#a-cnf-has-a-security-compromising-bug)
 
 In all of these examples, the CNFs using a non-root user for their container processes, have limited the scope of damage a compromised process may cause.
 

--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -83,7 +83,7 @@ Examples include
 
 In all of these examples, the CNFs using a non-root user for their container processes, have limited the scope of damage a compromised process may cause.
 
-See main [defense in depth for supply chain attacks](user-stories/supply-chain-attacks.md) document for more inforamtion.
+See main [defense in depth for supply chain attacks](../user-stories/supply-chain-attacks.md) document for more inforamtion.
 
 
 ### Tradeoffs/Constraints/Caveats/Notes

--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -78,10 +78,10 @@ User/group access enforcement will be respected. As an added advantage, fine-gra
 [Supply chain attacks](user-stories/supply-chain-attacks.md) are a risk at any point in the supply chain. ‘Defence in depth’ says that we should (a) defend against supply chain attacks but also (b) add mitigations in the case that supply chain attacks happen.
 
 Examples include
-- A CNF downloads compromised updates
-- A CNF succumbs to code injection
-- A CNF succumbs to malicious instructions
-- A CNF has a security-compromising bug
+- [A CNF downloads compromised updates](user-stories/supply-chain-attacks.md#a-cnf-downloads-compromised-updates)
+- [A CNF succumbs to code injection](user-stories/supply-chain-attacks.md#a-cnf-succumbs-to-code-injection)
+- [A CNF succumbs to malicious instructions](ser-stories/supply-chain-attacks.md#a-cnf-succumbs-to-malicious-instructions)
+- [A CNF has a security-compromising bug](user-stories/supply-chain-attacks.md#a-cnf-has-a-security-compromising-bug)
 
 In all of these examples, the CNFs using a non-root user for their container processes, have limited the scope of damage a compromised process may cause.
 

--- a/cbpps/0002-no-root-in-containers.md
+++ b/cbpps/0002-no-root-in-containers.md
@@ -6,9 +6,7 @@
   - [Goals](#Goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
-  - [User Stories](#user-stories)
-    - [Story 1](#story-1)
-    - [Story 2](#story-2)
+  - [User Stories](#user-story)
   - [Tradeoffs/Constraints/Caveats/Notes](#tradeoffsconstraintscaveatsnotes)
   - [References](#references)
   - [Alternatives (Optional)](#drawbacksalternatives)
@@ -73,7 +71,7 @@ User/group access enforcement will be respected. As an added advantage, fine-gra
 
 ### User Story
 
-## Supply chain attack user stories
+#### Supply chain attack user stories
 
 [Supply chain attacks](user-stories/supply-chain-attacks.md) are a risk at any point in the supply chain. ‘Defence in depth’ says that we should (a) defend against supply chain attacks but also (b) add mitigations in the case that supply chain attacks happen.
 

--- a/user-stories/supply-chain-attacks.md
+++ b/user-stories/supply-chain-attacks.md
@@ -14,7 +14,7 @@ Thus: limiting the privilege of container processes makes the system safer to us
 
 ## A CNF succumbs to code injection
 
-As above, a CNF runs malicious code, in this case introduced into the process through a code injection attack on its internal or external interfaces by a bad actor within the operator's organisation or by anyone on the network, respectively).  In this instance, limiting the power wielded by processes in the conatiner again prevents the attack from going further.
+As above, a CNF runs malicious code, in this case introduced into the process through a code injection attack on its internal or external interfaces by a bad actor within the operator's organisation or by anyone on the network, respectively.  In this instance, limiting the power wielded by processes in the container again prevents the attack from going further.
 
 ## A CNF succumbs to malicious instructions
 
@@ -24,6 +24,6 @@ A CNF such as a programmable forwarder might receive rules updates from a centra
 
 ## A CNF has a security-compromising bug
 
-A CNF unwittingly has a bug where an appropriately crafted packet will write a file at a location on the disk dependent on the packet's content.  This can lead to compromise.  Many possibilities for compromise are prevented if the process in question does not have overarching power to write the filesystem, as is typically available to a container root user.
+A CNF unwittingly has a bug where an appropriately crafted packet will write a file at a location on the disk dependent on the packet's content.  This can lead to compromise.  Many possibilities for compromise are prevented if the process in question does not have privileges to write in the filesystem, as is typically available to a container root user.
 
-A CNF may also have a bug where it attempts to rewrite settings files that keep the CNF secure (e.g. files containing credentials).  If the file is not owned by the process and the process is not itself a root process it has no power to change those files.
+A CNF may also have a bug where it attempts to rewrite settings files that keep the CNF secure (e.g. files containing credentials).  If the file is not owned by the process and the process is not itself a root process it has no privilege to change those files.

--- a/user-stories/supply-chain-attacks.md
+++ b/user-stories/supply-chain-attacks.md
@@ -1,0 +1,29 @@
+# User stories: Defense in Depth against Supply Chain Attacks
+
+Supply chain attacks are a risk at any point in the supply chain.  In a supply chain attack, a malicious actor sneaks code into the application that serves their nefarious purposes.  It can happen for many reasons: for instance, because they managed to modify the registry, they managed to modify the image before it was placed in the registry, or they managed to get illicit code into an open source project that is built into the container.
+
+'Defence in depth' says that we should (a) defend against supply chain attacks but also (b) add mitigations in the case that supply chain attacks happen - that is, we should not assume that a single line of defence will hold.
+
+## A CNF downloads compromised updates
+
+A CNF running on a K8s cluster is downloaded from a centralized registry.  Updates also come from this registry.  The operator installs new images in the centralised repository as they receive them from the CNF developer.
+
+In this case, if the operator ensures that processes in the container will be run as a normal conatiner user without extra rights, the malicious code will have a very limited ability to do dangerous things.  It will be harder for it to try to escalate its privileges, it has no rights outside of the conatiner, it cannot change files within the container that could cause more damage (such as root-owned settings files in /etc).
+
+Thus: limiting the privilege of container processes makes the system safer to use.
+
+## A CNF succumbs to code injection
+
+As above, a CNF runs malicious code, in this case introduced into the process through a code injection attack on its internal or external interfaces by a bad actor within the operator's organisation or by anyone on the network, respectively).  In this instance, limiting the power wielded by processes in the conatiner again prevents the attack from going further.
+
+## A CNF succumbs to malicious instructions
+
+As an example: the configuration of a CNF might allow the operator to determine paths where a log file is written.  If this path is set to a protected file, then the conatiner root user has the rights necessary to overwrite that file.  This could be exploited to change configuration and settings files within the conatiner image and subvert it.
+
+A CNF such as a programmable forwarder might receive rules updates from a central system.  Maliciously crafted rules might cause the process to attempt to do operations within its container that would compromise the container's security.  While it takes a successful attack to get malicious rules into the feed of updates, this means that such an attack can escalate to container control and perhaps further.  This can be limited if the process in the container is an unprivileged process running as a normal user without any capabilities, meaning that it cannot write files owned by other users.
+
+## A CNF has a security-compromising bug
+
+A CNF unwittingly has a bug where an appropriately crafted packet will write a file at a location on the disk dependent on the packet's content.  This can lead to compromise.  Many possibilities for compromise are prevented if the process in question does not have overarching power to write the filesystem, as is typically available to a container root user.
+
+A CNF may also have a bug where it attempts to rewrite settings files that keep the CNF secure (e.g. files containing credentials).  If the file is not owned by the process and the process is not itself a root process it has no power to change those files.


### PR DESCRIPTION
- added a new user stories directory with a set of supply chain attack
  stories
- reference these stories from the non-root best practice

Sign-off: Taylor Carpenter <taylor@vulk.coop>
Co-Author: Ian Wells <iawells@cisco.com>

This is an update to the best practice PR https://github.com/cncf/cnf-wg/pull/182 primarily for review by Ian and myself before merging to the main PR. As this is not merged into main directly, but instead goes into the other branch it will not require further approval.