### PR TITLE
fix linter issues in #345

### DIFF
--- a/events/telco-community-gathering-kubecon-eu-20230418.md
+++ b/events/telco-community-gathering-kubecon-eu-20230418.md
@@ -10,7 +10,7 @@
 - [CNF Certification](https://github.com/cncf/cnf-certification/#readme) - What it is about and how to get started, including hands-on support
 - [CNF Test Suite](https://github.com/cncf/cnf-testsuite#cnf-test-suite) - Using it as a development and ops tool, integrate into CI systems
 - Birds of a Feather presentations - short 5-10 minute presentation on topic of interest
-- [Open discussion](https://github.com/cncf/cnf-wg/discussions/257) - Time for various topics such as a wider discussion about CNF/Platform certification/interoperability approaches, problems,
+- [Open discussion](https://github.com/lfn-cnti/bestpractices/discussions/257) - Time for various topics such as a wider discussion about CNF/Platform certification/interoperability approaches, problems,
 processes, vendor(s) involvements, communities such as Sylva, LFN Anuket, etc.
 
 ## When is it?


### PR DESCRIPTION
linter checks failed due to broken link

 ERROR: 1 dead links found!
  [✖] https://github.com/cncf/cnf-wg/discussions/257 → Status: 404

link changed to:
https://github.com/lfn-cnti/bestpractices/discussions/257